### PR TITLE
Remove highlight searches

### DIFF
--- a/ideavimrc
+++ b/ideavimrc
@@ -30,9 +30,6 @@ set showmode
 " Enable line numbers
 set number
 
-" Highlight searches
-set hlsearch
-
 " Highlight dynamically as pattern is typed
 set incsearch
 


### PR DESCRIPTION
Remove highlight searches from ideavimrc, Searching with `s` is a more comfortable way in idea.